### PR TITLE
fix: add missing h1 on About and Home pages

### DIFF
--- a/src/components/pages/AboutPage.astro
+++ b/src/components/pages/AboutPage.astro
@@ -9,6 +9,10 @@ const t = useTranslations(lang);
 <BaseLayout title={t.about.title} description={t.about.description}>
   <div class="page">
 
+    <div class="page-header">
+      <h1>{t.about.title}</h1>
+    </div>
+
     <section class="vision">
       <p class="vision-label">{t.about.vision_title}</p>
       <blockquote>{t.about.vision}</blockquote>
@@ -51,6 +55,12 @@ const t = useTranslations(lang);
     display: flex;
     flex-direction: column;
     gap: 4rem;
+  }
+
+  .page-header h1 {
+    font-size: 2.4rem;
+    font-weight: 700;
+    color: var(--foreground);
   }
 
   /* Vision */

--- a/src/components/pages/AboutPage.astro
+++ b/src/components/pages/AboutPage.astro
@@ -57,6 +57,10 @@ const t = useTranslations(lang);
     gap: 4rem;
   }
 
+  .page-header {
+    margin-bottom: -2.5rem;
+  }
+
   .page-header h1 {
     font-size: 2.4rem;
     font-weight: 700;

--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -8,7 +8,9 @@ const t = useTranslations(lang);
 
 <BaseLayout title={t.nav.home} description={t.home.description}>
   <section class="hero">
-    <img src="/logo.svg" alt="She Shapes Tech" class="hero-logo" />
+    <h1 class="hero-logo">
+      <img src="/logo.svg" alt="She Shapes Tech" />
+    </h1>
     <p class="subtitle">{t.home.subtitle}</p>
   </section>
 
@@ -49,7 +51,15 @@ const t = useTranslations(lang);
 
   .hero-logo {
     width: 280px;
-    margin-bottom: 1.5rem;
+    margin: 0 auto 1.5rem;
+    display: block;
+    font-size: 0;
+    line-height: 0;
+  }
+
+  .hero-logo img {
+    width: 100%;
+    display: block;
   }
 
   .subtitle {


### PR DESCRIPTION
## Summary

- **AboutPage**: added `<h1>{t.about.title}</h1>` as page header — page previously jumped straight into Vision section without any h1
- **HomePage**: wrapped logo `<img>` in `<h1>` — standard pattern for logo-hero homepages; visual reset (`font-size: 0`, `line-height: 0`) ensures no layout change

Both fixes improve accessibility (screenreader page navigation) and SEO (search engines expect a clear h1 hierarchy).

## Test plan
- [x] Build succeeds
- [x] `dist/about/index.html` contains `<h1>Wer wir sind</h1>`
- [x] `dist/index.html` contains `<h1 class="hero-logo">`
- [x] Visual check: About page shows "Wer wir sind" heading above Vision section
- [x] Visual check: Home page logo renders identically to before

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)